### PR TITLE
review api and one to one with user-event

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,22 +1,21 @@
-# Active Context: Initial Project Analysis
+# Active Context: Review System Enhancements
 
 ## Current Focus
 
-The current task is to populate the Memory Bank for the Geohod backend project. This involves analyzing the existing codebase to create a set of core documentation files that will guide future development.
+The current focus was on enhancing the review system to enforce one-to-one user-to-event reviews and provide an API endpoint to retrieve a user's existing review for an event.
 
 ## Recent Changes
 
-*   Initialized the Memory Bank by creating the following files:
-    *   `projectBrief.md`: High-level project overview.
-    *   `productContext.md`: The "why" behind the project.
-    *   `techContext.md`: The technology stack and technical details.
-    *   `systemPatterns.md`: The application's architecture and design patterns.
+*   Implemented a database unique constraint to prevent duplicate reviews.
+*   Updated the `submitReview` method in `ReviewServiceImpl` to implement upsert logic.
+*   Added a new API endpoint `GET /api/v2/reviews/event/{eventId}/my-review` in `ReviewController`.
+*   Implemented the `getUserReviewForEvent` method in `ReviewServiceImpl`.
+*   The keyset pagination fix has been successfully implemented and tested.
 
 ## Next Steps
 
-1.  Create the `progress.md` file to document the current state of the project from a development perspective.
-2.  Review the newly created Memory Bank files for accuracy and completeness.
-3.  Begin work on any active development tasks, using the Memory Bank as a guide.
+1.  Review the newly updated Memory Bank files for accuracy and completeness.
+2.  Begin work on any active development tasks, using the Memory Bank as a guide.
 
 ## Key Learnings & Insights
 
@@ -24,3 +23,4 @@ The current task is to populate the Memory Bank for the Geohod backend project. 
 *   The reliance on Telegram for authentication is a critical and unique feature.
 *   The use of `spring-data-jdbc` over `spring-data-jpa` is a significant architectural decision, suggesting a preference for more direct SQL control.
 *   The system includes advanced patterns like the Outbox pattern for reliable notifications.
+*   The review system now enforces one-to-one user-to-event reviews and provides an API endpoint to retrieve a user's existing review for an event.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -21,13 +21,14 @@ Based on the initial analysis of the codebase and `README.md`, the following cor
 
 ## Current Status
 
-*   **Memory Bank Updated:** Successfully updated the Memory Bank to reflect the completion of the keyset pagination fix for the notification processors.
+*   **Memory Bank Updated:** Successfully updated the Memory Bank to reflect the completion of the keyset pagination fix for the notification processors and the review system enhancements.
 *   **Bug Fix Completed:** Successfully resolved the critical bug where in-app and Telegram-bot notifications were not being delivered due to flawed `UUID` ordering in event log processing.
 *   **Keyset Pagination Implemented:** Replaced the non-sequential `UUID` cursor with a composite `(createdAt, id)` cursor for reliable event log processing.
 *   **Database Migration:** Added Liquibase migration `db.changelog-1.7-keyset-pagination-fix.xml` to support the new cursor structure.
 *   **Code Changes:** Updated `EventLogServiceImpl`, `NotificationProcessorProgressServiceImpl`, `InAppNotificationProcessor`, `TelegramNotificationProcessor`, and corresponding tests to use the new cursor logic.
 *   **Build Status:** All compilation errors have been resolved.
+*   **Review System Enhancements**: Implemented one-to-one user-to-event reviews and provided an API endpoint to retrieve a user's existing review for an event.
 
 ## Known Issues & Blockers
 
-*   **No Known Issues:** The keyset pagination fix has been successfully implemented and tested. No known issues or blockers remain for this specific bug.
+*   **No Known Issues:** The keyset pagination fix and review system enhancements have been successfully implemented and tested. No known issues or blockers remain.

--- a/src/main/java/me/geohod/geohodbackend/api/controller/v2/ReviewController.java
+++ b/src/main/java/me/geohod/geohodbackend/api/controller/v2/ReviewController.java
@@ -1,5 +1,16 @@
 package me.geohod.geohodbackend.api.controller.v2;
 
+import java.util.UUID;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import lombok.RequiredArgsConstructor;
 import me.geohod.geohodbackend.api.dto.review.ReviewCreateRequest;
 import me.geohod.geohodbackend.api.dto.review.ReviewResponse;
@@ -8,11 +19,6 @@ import me.geohod.geohodbackend.api.response.ApiResponse;
 import me.geohod.geohodbackend.data.model.review.Review;
 import me.geohod.geohodbackend.security.principal.TelegramPrincipal;
 import me.geohod.geohodbackend.service.IReviewService;
-import me.geohod.geohodbackend.service.IUserRatingService;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v2/reviews")
@@ -27,6 +33,19 @@ public class ReviewController {
             @AuthenticationPrincipal TelegramPrincipal principal) {
         Review review = reviewService.submitReview(principal.userId(), request);
         return ApiResponse.success(reviewApiMapper.map(review));
+    }
+
+    @GetMapping("/event/{eventId}/my-review")
+    public ApiResponse<ReviewResponse> getMyReviewForEvent(
+            @PathVariable UUID eventId,
+            @AuthenticationPrincipal TelegramPrincipal principal) {
+        var reviewOptional = reviewService.getUserReviewForEvent(principal.userId(), eventId);
+        if (reviewOptional.isPresent()) {
+            ReviewResponse response = reviewApiMapper.map(reviewOptional.get());
+            return ApiResponse.success(response);
+        } else {
+            return new ApiResponse<>("ERROR", "Review not found for this event", null);
+        }
     }
 
     @PatchMapping("/{id}/hide")
@@ -44,4 +63,4 @@ public class ReviewController {
         reviewService.unhideReview(id, principal.userId());
         return ApiResponse.success(null);
     }
-} 
+}

--- a/src/main/java/me/geohod/geohodbackend/data/model/repository/ReviewRepository.java
+++ b/src/main/java/me/geohod/geohodbackend/data/model/repository/ReviewRepository.java
@@ -1,6 +1,10 @@
 package me.geohod.geohodbackend.data.model.repository;
 
-import me.geohod.geohodbackend.data.model.review.Review;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jdbc.repository.query.Query;
@@ -8,16 +12,15 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import me.geohod.geohodbackend.data.model.review.Review;
 
 @Repository
 public interface ReviewRepository extends CrudRepository<Review, UUID>, PagingAndSortingRepository<Review, UUID> {
     Optional<Review> findByIdAndAuthorId(UUID eventId, UUID authorId);
     List<Review> findByEventId(UUID eventId);
     Page<Review> findByEventId(UUID eventId, Pageable pageable);
+    
+    Optional<Review> findByEventIdAndAuthorId(UUID eventId, UUID authorId);
     
     @Query("SELECT r.* FROM reviews r " +
            "JOIN events e ON r.event_id = e.id " +
@@ -83,4 +86,4 @@ public interface ReviewRepository extends CrudRepository<Review, UUID>, PagingAn
            "WHERE e.author_id = :userId " +
            "AND (:showHidden = true OR r.is_hidden = false)")
     long countReviewsWithAuthorForUser(UUID userId, boolean showHidden);
-} 
+}

--- a/src/main/java/me/geohod/geohodbackend/data/model/review/Review.java
+++ b/src/main/java/me/geohod/geohodbackend/data/model/review/Review.java
@@ -1,16 +1,17 @@
 package me.geohod.geohodbackend.data.model.review;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.time.Instant;
+import java.util.UUID;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Table;
 
-import java.time.Instant;
-import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter(AccessLevel.PRIVATE)
@@ -47,8 +48,16 @@ public class Review implements Persistable<UUID> {
         this.isHidden = false;
     }
 
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
     @Override
     public boolean isNew() {
         return version == null;
     }
-} 
+}

--- a/src/main/java/me/geohod/geohodbackend/service/IReviewService.java
+++ b/src/main/java/me/geohod/geohodbackend/service/IReviewService.java
@@ -1,12 +1,14 @@
 package me.geohod.geohodbackend.service;
 
-import me.geohod.geohodbackend.api.dto.review.ReviewCreateRequest;
-import me.geohod.geohodbackend.data.dto.ReviewWithAuthorDto;
-import me.geohod.geohodbackend.data.model.review.Review;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.UUID;
+import me.geohod.geohodbackend.api.dto.review.ReviewCreateRequest;
+import me.geohod.geohodbackend.data.dto.ReviewWithAuthorDto;
+import me.geohod.geohodbackend.data.model.review.Review;
 
 public interface IReviewService {
     Review submitReview(UUID authorId, ReviewCreateRequest request);
@@ -14,4 +16,5 @@ public interface IReviewService {
     void unhideReview(UUID reviewId, UUID userId);
     Page<Review> getReviewsForUser(UUID userId, Pageable pageable);
     Page<ReviewWithAuthorDto> getReviewsWithAuthorForUser(UUID userId, UUID requestingUserId, Pageable pageable);
-} 
+    Optional<Review> getUserReviewForEvent(UUID userId, UUID eventId);
+}

--- a/src/main/resources/db/changelog/db.changelog-1.8-review-unique-constraint.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.8-review-unique-constraint.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-unique-constraint-reviews-event-author" author="naborshchikov">
+        <addUniqueConstraint 
+            tableName="reviews" 
+            columnNames="event_id, author_id" 
+            constraintName="uk_reviews_event_author"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -11,4 +11,5 @@
     <include file="db.changelog-1.5-notifications.xml" relativeToChangelogFile="true"/>
     <include file="db.changelog-1.6-user_settings.xml" relativeToChangelogFile="true"/>
     <include file="db.changelog-1.7-keyset-pagination-fix.xml" relativeToChangelogFile="true"/>
+    <include file="db.changelog-1.8-review-unique-constraint.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Перед отправкой отзыва фронтенд может вызвать `GET /api/v2/reviews/event/{eventId}/my-review`, чтобы проверить, существует ли отзыв. Для:

Предварительного заполнения формы отзыва существующими данными.
Изменения текста пользовательского интерфейса с «Оставить отзыв» на «Обновить отзыв».

Эндпоинт `POST /api/v2/reviews` для нового отзыва, так и для обновления. Бэк автоматом обработает сохранить/обновить

Поле `result` в `ApiResponse` нужно проверять на значение `ERROR` была ли операция успешной или произошла ошибка, даже если код состояния 200 (в данным случае если отзыва не существует по запрошенному eventId)