### PR TITLE
feat: support Telegram Login Widget id_token in OIDC auth endpoint

### DIFF
--- a/src/main/java/me/geohod/geohodbackend/auth/api/AuthController.java
+++ b/src/main/java/me/geohod/geohodbackend/auth/api/AuthController.java
@@ -66,7 +66,7 @@ public class AuthController {
         Object providerRequest = switch (request.providerType()) {
             case TELEGRAM -> request.oidcCode() != null
                     ? new TelegramOidcLoginRequest(request.oidcCode(), request.redirectUri(),
-                            request.codeVerifier(), request.nonce())
+                            request.codeVerifier(), request.nonce(), null)
                     : new TelegramLoginRequest(request.initData());
             case EMAIL -> new EmailOtpVerifyRequest(request.email(), request.code());
         };

--- a/src/main/java/me/geohod/geohodbackend/auth/api/dto/TelegramOidcLoginRequest.java
+++ b/src/main/java/me/geohod/geohodbackend/auth/api/dto/TelegramOidcLoginRequest.java
@@ -3,8 +3,9 @@ package me.geohod.geohodbackend.auth.api.dto;
 import org.springframework.lang.Nullable;
 
 public record TelegramOidcLoginRequest(
-        String code,
-        String redirectUri,
+        @Nullable String code,
+        @Nullable String redirectUri,
         @Nullable String codeVerifier,
-        @Nullable String nonce
+        @Nullable String nonce,
+        @Nullable String idToken
 ) {}

--- a/src/main/java/me/geohod/geohodbackend/auth/provider/TelegramAuthProvider.java
+++ b/src/main/java/me/geohod/geohodbackend/auth/provider/TelegramAuthProvider.java
@@ -30,8 +30,12 @@ public class TelegramAuthProvider implements AuthProvider {
                     data.lastName(), data.photoUrl());
         }
         if (request instanceof TelegramOidcLoginRequest r) {
-            OidcUserInfo data = telegramOidcClient.exchangeAndVerify(
-                    r.code(), r.redirectUri(), r.codeVerifier(), r.nonce());
+            if (r.idToken() == null && r.code() == null) {
+                throw new IllegalArgumentException("Either idToken or code must be provided for Telegram OIDC authentication");
+            }
+            OidcUserInfo data = r.idToken() != null
+                    ? telegramOidcClient.verifyDirectIdToken(r.idToken(), r.nonce())
+                    : telegramOidcClient.exchangeAndVerify(r.code(), r.redirectUri(), r.codeVerifier(), r.nonce());
             return AuthProviderResult.authenticatedWithProfile(
                     data.telegramUserId(), AuthProviderType.TELEGRAM,
                     data.username(), data.name(),

--- a/src/main/java/me/geohod/geohodbackend/auth/telegram/TelegramOidcClient.java
+++ b/src/main/java/me/geohod/geohodbackend/auth/telegram/TelegramOidcClient.java
@@ -79,6 +79,12 @@ public class TelegramOidcClient {
         return extractUserInfo(claims);
     }
 
+    public OidcUserInfo verifyDirectIdToken(String idToken, @Nullable String nonce) {
+        JWTClaimsSet claims = verifyIdToken(idToken);
+        validateNonce(claims, nonce);
+        return extractUserInfo(claims);
+    }
+
     @SuppressWarnings("unchecked")
     private String exchangeCodeForIdToken(String code, String redirectUri, @Nullable String codeVerifier) {
         var oidcConfig = properties.security().telegramOidc();

--- a/src/test/java/me/geohod/geohodbackend/auth/api/AuthControllerTelegramOidcTest.java
+++ b/src/test/java/me/geohod/geohodbackend/auth/api/AuthControllerTelegramOidcTest.java
@@ -31,7 +31,7 @@ class AuthControllerTelegramOidcTest {
 
     @Test
     void telegramOidcLogin_validRequest_returnsTokens() {
-        var request = new TelegramOidcLoginRequest("auth-code", "https://example.com/callback", "verifier", "nonce");
+        var request = new TelegramOidcLoginRequest("auth-code", "https://example.com/callback", "verifier", "nonce", null);
         when(authService.authenticate(eq(AuthProviderType.TELEGRAM), any(TelegramOidcLoginRequest.class)))
                 .thenReturn(AuthTokenResponse.tokens("access-12345", "refresh-45678910"));
 
@@ -46,7 +46,7 @@ class AuthControllerTelegramOidcTest {
 
     @Test
     void telegramOidcLogin_authServiceThrowsSecurity_propagatesException() {
-        var request = new TelegramOidcLoginRequest("bad-code", "https://example.com/callback", null, null);
+        var request = new TelegramOidcLoginRequest("bad-code", "https://example.com/callback", null, null, null);
         when(authService.authenticate(eq(AuthProviderType.TELEGRAM), any()))
                 .thenThrow(new SecurityException("OIDC verification failed"));
 

--- a/src/test/java/me/geohod/geohodbackend/auth/provider/TelegramAuthProviderTest.java
+++ b/src/test/java/me/geohod/geohodbackend/auth/provider/TelegramAuthProviderTest.java
@@ -58,7 +58,7 @@ class TelegramAuthProviderTest {
 
     @Test
     void authenticate_withOidcRequest_delegatesToOidcClient() {
-        var request = new TelegramOidcLoginRequest("auth-code", "https://redirect.url", "verifier", "nonce");
+        var request = new TelegramOidcLoginRequest("auth-code", "https://redirect.url", "verifier", "nonce", null);
         var oidcUserInfo = new OidcUserInfo("99999", "Jane Doe", "janedoe", "https://photo.url");
         when(telegramOidcClient.exchangeAndVerify("auth-code", "https://redirect.url", "verifier", "nonce"))
                 .thenReturn(oidcUserInfo);
@@ -72,6 +72,44 @@ class TelegramAuthProviderTest {
         assertEquals("Jane Doe", result.firstName());
         verify(telegramOidcClient).exchangeAndVerify("auth-code", "https://redirect.url", "verifier", "nonce");
         verifyNoInteractions(telegramInitDataVerifier);
+    }
+
+    @Test
+    void authenticate_withOidcIdToken_delegatesToDirectVerification() {
+        var request = new TelegramOidcLoginRequest(null, null, null, "nonce", "eyJ.direct.token");
+        var oidcUserInfo = new OidcUserInfo("99999", "Jane Doe", "janedoe", "https://photo.url");
+        when(telegramOidcClient.verifyDirectIdToken("eyJ.direct.token", "nonce"))
+                .thenReturn(oidcUserInfo);
+
+        AuthProviderResult result = telegramAuthProvider.authenticate(request);
+
+        assertEquals("99999", result.providerId());
+        assertEquals(AuthProviderType.TELEGRAM, result.type());
+        assertTrue(result.authenticated());
+        verify(telegramOidcClient).verifyDirectIdToken("eyJ.direct.token", "nonce");
+        verifyNoMoreInteractions(telegramOidcClient);
+        verifyNoInteractions(telegramInitDataVerifier);
+    }
+
+    @Test
+    void authenticate_withOidcIdTokenAndNoNonce_delegatesToDirectVerificationWithNullNonce() {
+        var request = new TelegramOidcLoginRequest(null, null, null, null, "eyJ.direct.token");
+        var oidcUserInfo = new OidcUserInfo("99999", "Jane Doe", "janedoe", null);
+        when(telegramOidcClient.verifyDirectIdToken("eyJ.direct.token", null))
+                .thenReturn(oidcUserInfo);
+
+        AuthProviderResult result = telegramAuthProvider.authenticate(request);
+
+        assertTrue(result.authenticated());
+        verify(telegramOidcClient).verifyDirectIdToken("eyJ.direct.token", null);
+    }
+
+    @Test
+    void authenticate_withOidcRequestMissingBothCodeAndIdToken_throwsIllegalArgumentException() {
+        var request = new TelegramOidcLoginRequest(null, null, null, null, null);
+
+        assertThrows(IllegalArgumentException.class, () -> telegramAuthProvider.authenticate(request));
+        verifyNoInteractions(telegramOidcClient);
     }
 
     @Test

--- a/src/test/java/me/geohod/geohodbackend/auth/telegram/TelegramOidcClientTest.java
+++ b/src/test/java/me/geohod/geohodbackend/auth/telegram/TelegramOidcClientTest.java
@@ -85,6 +85,13 @@ class TelegramOidcClientTest {
     }
 
     @Test
+    void verifyDirectIdToken_invalidToken_throwsSecurityException() {
+        // jwtProcessor is null (init() not called) — verifyIdToken wraps any exception as SecurityException
+        assertThrows(SecurityException.class,
+                () -> oidcClient.verifyDirectIdToken("not.a.valid.jwt", null));
+    }
+
+    @Test
     void extractUserInfo_missingOptionalFields_returnsNulls() {
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
                 .subject("99999")


### PR DESCRIPTION
Add idToken path to POST /api/v2/auth/telegram-oidc so frontends using the Telegram Login Widget can authenticate by passing the id_token directly, without a server-side code exchange. Verifies via existing JWKS logic.