### PR TITLE
fix: disable scheduling in tests to prevent post-shutdown DB errors

### DIFF
--- a/src/main/java/me/geohod/geohodbackend/configuration/ApplicationConfiguration.java
+++ b/src/main/java/me/geohod/geohodbackend/configuration/ApplicationConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
@@ -17,7 +16,6 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 @RequiredArgsConstructor
 @Configuration
 @EnableAsync
-@EnableScheduling
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @EnableConfigurationProperties(GeohodProperties.class)
 @ConfigurationPropertiesScan("me.geohod.geohodbackend.configuration.properties")

--- a/src/main/java/me/geohod/geohodbackend/configuration/SchedulingConfiguration.java
+++ b/src/main/java/me/geohod/geohodbackend/configuration/SchedulingConfiguration.java
@@ -1,0 +1,11 @@
+package me.geohod.geohodbackend.configuration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "geohod.scheduling.enabled", havingValue = "true", matchIfMissing = true)
+public class SchedulingConfiguration {
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 geohod:
+  scheduling:
+    enabled: false
   telegram-bot:
     token: test-token
     username: test_bot


### PR DESCRIPTION
Purpose of the PR:
CI tests failing with CannotCreateTransactionException

Solution:
extracted @EnableScheduling from ApplicationConfiguration into a dedicated SchedulingConfiguration guarded by @ConditionalOnProperty `geohod.scheduling.enabled`